### PR TITLE
Use node:alpine-14 base image

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS build
+FROM node:14-alpine AS build
 WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
 RUN npm install


### PR DESCRIPTION
"npm run localdocker" fails in the generated docker container.

It appears that when this project was originally created and tested, node and npm were at lower "latest" versions. node:alpine now includes node v17.4.0 and npm 8.3.1. When "npm run localdocker" is now run in the container, we get errors as shown down below.

Searching the cause of these errors, I found that they are related to changes made in a newer version of node/npm. I found that I needed to go back to node v14 to resolve these errors -- and numerous warnings "npm WARN EBADENGINE Unsupported engine" while running "npm install".

I changed client/Dockerfile to use:
` "FROM node:14-alpine AS build" `

The client docker build now succeed without errors.

> …
> Compiling @angular/material/table : es2015 as esm2015
> ⠙ Generating browser application bundles (phase: building)...node:internal/crypto/hash:67
>   this[kHandle] = new _Hash(algorithm, xofLen);
>                   ^
> Error: error:0308010C:digital envelope routines::unsupported
>     at new Hash (node:internal/crypto/hash:67:19)
>     at Object.createHash (node:crypto:135:10)
>     at module.exports (/usr/src/app/node_modules/webpack/lib/util/createHash.js:135:53)
>     at NormalModule._initBuildHash (/usr/src/app/node_modules/webpack/lib/NormalModule.js:417:16)
>     at /usr/src/app/node_modules/webpack/lib/NormalModule.js:452:10
>     at /usr/src/app/node_modules/webpack/lib/NormalModule.js:323:13
>     at /usr/src/app/node_modules/loader-runner/lib/LoaderRunner.js:367:11
>     at /usr/src/app/node_modules/loader-runner/lib/LoaderRunner.js:172:11
>     at loadLoader (/usr/src/app/node_modules/loader-runner/lib/loadLoader.js:32:11)
>     at iteratePitchingLoaders (/usr/src/app/node_modules/loader-runner/lib/LoaderRunner.js:169:2)
>     at runLoaders (/usr/src/app/node_modules/loader-runner/lib/LoaderRunner.js:365:2)
>     at NormalModule.doBuild (/usr/src/app/node_modules/webpack/lib/NormalModule.js:295:3)
>     at NormalModule.build (/usr/src/app/node_modules/webpack/lib/NormalModule.js:446:15)
>     at Compilation.buildModule (/usr/src/app/node_modules/webpack/lib/Compilation.js:739:10)
>     at /usr/src/app/node_modules/webpack/lib/Compilation.js:1111:12
>     at /usr/src/app/node_modules/webpack/lib/NormalModuleFactory.js:409:6 {
>   opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
>   library: 'digital envelope routines',
>   reason: 'unsupported',
>   code: 'ERR_OSSL_EVP_UNSUPPORTED'
> }
> Node.js v17.4.0
> npm ERR! code ELIFECYCLE
> npm ERR! errno 1
> npm ERR! client@0.0.0 localdocker: `ng build --configuration=localdocker`
> npm ERR! Exit status 1
> npm ERR!
> npm ERR! Failed at the client@0.0.0 localdocker script.
> npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
> npm ERR! A complete log of this run can be found in:
> npm ERR!     /root/.npm/_logs/2022-01-29T21_36_56_632Z-debug.log